### PR TITLE
fix:cannot re-render if dom is deleted <Update echarts.ts>

### DIFF
--- a/src/composables/echarts.ts
+++ b/src/composables/echarts.ts
@@ -130,6 +130,10 @@ export function useEcharts(
   const stopSizeWatch = watch([width, height], ([newWidth, newHeight]) => {
     initialSize.width = newWidth;
     initialSize.height = newHeight;
+		if (newWidth === 0 && newHeight === 0) {
+      // 节点被删除 将chart置为空
+      chart = null
+    }
     if (canRender()) {
       if (!isRendered()) {
         render();


### PR DESCRIPTION
fix:cannot re-render if dom is deleted

If the chart is opened in the pop-up window, opening the chart again will not display properly.