### PR TITLE
fix(components): 修复路由在path中包含重复路单词径菜单时，被激活会错误展开

### DIFF
--- a/src/utils/router/menu.ts
+++ b/src/utils/router/menu.ts
@@ -45,7 +45,7 @@ export function getActiveKeyPathsOfMenus(activeKey: string, menus: App.GlobalMen
 
 function getActiveKeyPathsOfMenu(activeKey: string, menu: App.GlobalMenuOption) {
   const keys: string[] = [];
-  if (activeKey.includes(menu.routeName)) {
+  if (activeKey.startsWith(menu.routeName)) {
     keys.push(menu.routeName);
   }
   if (menu.children) {


### PR DESCRIPTION
如：
路由1：/setting/product
路由2：/product/another
路由3：/yet-another/product-list

在路由1激活时，菜单中路由2，3所对应菜单项会被错误展开