### PR TITLE
feat(projects): 抽离部分登陆逻辑，支持Token或JWT校验方式

### DIFF
--- a/mock/api/auth.ts
+++ b/mock/api/auth.ts
@@ -23,7 +23,7 @@ const apis: MockMethod[] = [
   {
     url: '/mock/login',
     method: 'post',
-    response: (options: Service.MockOption): Service.MockServiceResult<ApiAuth.Token | null> => {
+    response: (options: Service.MockOption): Service.MockServiceResult<ApiAuth.JWT | null> => {
       const { userName = undefined, password = undefined } = options.body;
 
       if (!userName || !password) {
@@ -101,7 +101,7 @@ const apis: MockMethod[] = [
   {
     url: '/mock/updateToken',
     method: 'post',
-    response: (options: Service.MockOption): Service.MockServiceResult<ApiAuth.Token | null> => {
+    response: (options: Service.MockOption): Service.MockServiceResult<ApiAuth.JWT | null> => {
       const { refreshToken = '' } = options.body;
 
       const findItem = userModel.find(item => item.refreshToken === refreshToken);

--- a/src/service/api/auth.ts
+++ b/src/service/api/auth.ts
@@ -10,12 +10,21 @@ export function fetchSmsCode(phone: string) {
 }
 
 /**
- * 登录
+ * 登录（Token认证方式）
  * @param userName - 用户名
  * @param password - 密码
  */
-export function fetchLogin(userName: string, password: string) {
+export function fetchLoginToken(userName: string, password: string) {
   return mockRequest.post<ApiAuth.Token>('/login', { userName, password });
+}
+
+/**
+ * 登录（JWT认证方式）
+ * @param userName - 用户名
+ * @param password - 密码
+ */
+export function fetchLoginJWT(userName: string, password: string) {
+  return mockRequest.post<ApiAuth.JWT>('/login', { userName, password });
 }
 
 /** 获取用户信息 */
@@ -37,5 +46,5 @@ export function fetchUserRoutes(userId: string) {
  * @param refreshToken
  */
 export function fetchUpdateToken(refreshToken: string) {
-  return mockRequest.post<ApiAuth.Token>('/updateToken', { refreshToken });
+  return mockRequest.post<ApiAuth.JWT>('/updateToken', { refreshToken });
 }

--- a/src/service/request/instance.ts
+++ b/src/service/request/instance.ts
@@ -9,7 +9,7 @@ import {
   handleServiceResult,
   transformRequestData
 } from '@/utils';
-import { handleRefreshToken } from './helpers';
+import { defaultAuthType } from '@/store/modules/auth/auth-type';
 
 /**
  * 封装axios请求类
@@ -71,7 +71,7 @@ export default class CustomAxiosInstance {
 
           // token失效, 刷新token
           if (REFRESH_TOKEN_CODE.includes(backend[codeKey])) {
-            const config = await handleRefreshToken(response.config);
+            const config = await defaultAuthType.handleTokenFailure(response.config);
             if (config) {
               return this.instance.request(config);
             }

--- a/src/store/modules/auth/auth-type.ts
+++ b/src/store/modules/auth/auth-type.ts
@@ -1,0 +1,46 @@
+import type { AxiosRequestConfig } from 'axios';
+import { fetchLoginToken, fetchLoginJWT } from '@/service';
+import { useAuthStore } from '@/store';
+import { localStg } from '@/utils';
+import { handleRefreshToken } from '@/service/request/helpers';
+
+const TokenAuth = {
+  /** 获取token的接口 */
+  fetchLogin: fetchLoginToken,
+  /** 请求登录成功后的数据处理回调 */
+  handleAuthToken(backendToken: ApiAuth.Token) {
+    // 先把token存储到缓存中(后面接口的请求头需要token)
+    const { token } = backendToken;
+    // token由后端控制刷新，不需要前端处理刷新逻辑
+    localStg.set('token', token, null);
+  },
+  /** Token失效后的回调 */
+  async handleTokenFailure(_: AxiosRequestConfig) {
+    // token失效说明已经超过了可刷新token时间，需要重新登录
+    const { resetAuthStore } = useAuthStore();
+    resetAuthStore();
+  }
+};
+
+const JWTAuth = {
+  fetchLogin: fetchLoginJWT,
+  /** 请求登录成功后的数据处理回调 */
+  handleAuthToken(backendToken: ApiAuth.JWT) {
+    // 先把token存储到缓存中(后面接口的请求头需要token)
+    const { token, refreshToken } = backendToken;
+    localStg.set('token', token);
+    localStg.set('refreshToken', refreshToken);
+  },
+  /** Token失效后的回调 */
+  async handleTokenFailure(axiosConfig: AxiosRequestConfig) {
+    return handleRefreshToken(axiosConfig);
+  }
+};
+
+/**
+ * 选择需要使用哪种认证方式，默认选择JWT方式
+ */
+const defaultAuthType = JWTAuth;
+
+// 如果只使用JWTAuth，不导出会导致TokenAuth报未使用的ts、eslint错误
+export { defaultAuthType, JWTAuth, TokenAuth };

--- a/src/typings/api.d.ts
+++ b/src/typings/api.d.ts
@@ -2,8 +2,12 @@
 
 /** 后端返回的用户权益相关类型 */
 declare namespace ApiAuth {
-  /** 返回的token和刷新token */
+  /** 返回的token */
   interface Token {
+    token: string;
+  }
+  /** 返回的token和刷新token */
+  interface JWT {
     token: string;
     refreshToken: string;
   }


### PR DESCRIPTION
原有的JWT方式不能符合部分场景，比如：
- JWT是无状态的，无法让已发布的令牌失效
- 同样没办法做到单点登录

所以有些后台管理系统如果需要踢人、单点登录的话，使用Token的方式更加合适。
所以希望添加能切换认证方式的功能。