### PR TITLE
fix(projects): the length of routes children list should greater than 0

### DIFF
--- a/src/utils/router/menu.ts
+++ b/src/utils/router/menu.ts
@@ -10,7 +10,7 @@ export function transformAuthRouteToMenu(routes: AuthRoute.Route[]): App.GlobalM
     const { name, path, meta } = route;
     const routeName = name as string;
     let menuChildren: App.GlobalMenuOption[] | undefined;
-    if (route.children) {
+    if (route.children && route.children.length > 0) {
       menuChildren = transformAuthRouteToMenu(route.children);
     }
     const menuItem: App.GlobalMenuOption = addPartialProps({


### PR DESCRIPTION
If the backend passes in an empty list `children: []`, some elements of the navigation bar will not be clickable