### PR TITLE
feat(utils): deep fields in the response can be specified in the backendConfig

### DIFF
--- a/src/service/request/instance.ts
+++ b/src/service/request/instance.ts
@@ -7,7 +7,8 @@ import {
   handleBackendError,
   handleResponseError,
   handleServiceResult,
-  transformRequestData
+  transformRequestData,
+  getDeepResponseWithKey
 } from '@/utils';
 import { handleRefreshToken } from './helpers';
 
@@ -64,13 +65,16 @@ export default class CustomAxiosInstance {
         if (status === 200 || status < 300 || status === 304) {
           const backend = response.data;
           const { codeKey, dataKey, successCode } = this.backendConfig;
+
+          const code = getDeepResponseWithKey(backend, codeKey);
           // 请求成功
-          if (backend[codeKey] === successCode) {
-            return handleServiceResult(null, backend[dataKey]);
+          if (code === successCode) {
+            const data = getDeepResponseWithKey(backend, dataKey);
+            return handleServiceResult(null, data);
           }
 
           // token失效, 刷新token
-          if (REFRESH_TOKEN_CODE.includes(backend[codeKey])) {
+          if (REFRESH_TOKEN_CODE.includes(code)) {
             const config = await handleRefreshToken(response.config);
             if (config) {
               return this.instance.request(config);

--- a/src/utils/service/error.ts
+++ b/src/utils/service/error.ts
@@ -8,6 +8,7 @@ import {
   REQUEST_TIMEOUT_CODE,
   REQUEST_TIMEOUT_MSG
 } from '@/config';
+import { getDeepResponseWithKey } from '@/utils';
 import { exeStrategyActions } from '../common';
 import { showErrorMsg } from './msg';
 
@@ -91,8 +92,8 @@ export function handleBackendError(backendResult: Record<string, any>, config: S
   const { codeKey, msgKey } = config;
   const error: Service.RequestError = {
     type: 'backend',
-    code: backendResult[codeKey],
-    msg: backendResult[msgKey]
+    code: getDeepResponseWithKey(backendResult, codeKey),
+    msg: getDeepResponseWithKey(backendResult, msgKey)
   };
 
   showErrorMsg(error);

--- a/src/utils/service/transform.ts
+++ b/src/utils/service/transform.ts
@@ -59,3 +59,11 @@ async function transformFile(formData: FormData, key: string, file: File[] | Fil
     formData.append(key, file);
   }
 }
+
+export function getDeepResponseWithKey(res: any, key: string) {
+  let result = res;
+  key.split('.').forEach(item => {
+    result = result[item];
+  });
+  return result;
+}


### PR DESCRIPTION
为 `backendConfig` 中的 `codeKey` `msgKey` `dataKey` 提供深层字段名支持。

例如，当响应消息为如下结构：
```
{
    "status": {
        "retCode": 411,
        "msg": "错误，请重试"
    },
    "data"：{/* 一些数据 */}
    "currentTime": 1677572295121
}
```

创建实例可进行如下配置：
```
export const mockRequest = createRequest(
  { baseURL: '/mock' },
  { codeKey: 'status.retCode', msgKey: 'status.msg', dataKey: 'data', successCode: 200 }
);
```
