### PR TITLE
fix(utils): make AxiosRequestConfig optional for request.handleDelete()

### DIFF
--- a/src/service/request/request.ts
+++ b/src/service/request/request.ts
@@ -77,7 +77,7 @@ export function createRequest(axiosConfig: AxiosRequestConfig, backendConfig?: S
    * @param url - 请求地址
    * @param config - axios配置
    */
-  function handleDelete<T>(url: string, config: AxiosRequestConfig) {
+  function handleDelete<T>(url: string, config?: AxiosRequestConfig) {
     return asyncRequest<T>({ url, method: 'delete', axiosConfig: config });
   }
 


### PR DESCRIPTION
## Pull Request 详情

请根据实际使用情况修改以下信息。

## 版本信息
0.9.8

## 解决了哪些问题
把 `src/service/request/request.ts` 中的 `handleDelete` 方法的参数 `AxiosRequestConfig` 从**必要**改为_可选_

## 是否关闭了某个 Issue

Closes #
