### PR TITLE
fix(projects): tsconfig missing isolatedModules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "preserve",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "noUnusedLocals": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Pull Request 详情

请根据实际使用情况修改以下信息。

## 版本信息

## 解决了哪些问题
See: https://vuejs.org/guide/typescript/overview.html#configuring-tsconfig-json
I noticed that the Vue documentation mentions some details about configuring tsconfig.json, including various options and project references. In particular, there is an important configuration option mentioned: compilerOptions.isolatedModules, which is set to true because Vite uses esbuild for TypeScript transpilation and is subject to single-file transpile limitations.

However, I noticed that this option is not configured in our project's tsconfig.json. 
## 是否关闭了某个 Issue

Closes #
