### PR TITLE
修复生产环境续修改主题配置文件不会生效和用户管理页面无法滚动的问题

### DIFF
--- a/src/composables/events.ts
+++ b/src/composables/events.ts
@@ -14,6 +14,7 @@ export function useGlobalEvents() {
 
   /** 页面离开时缓存多页签数据 */
   useEventListener(window, 'beforeunload', () => {
+		theme.resetThemeStore()
     theme.cacheThemeSettings();
     tab.cacheTabRoutes();
   });

--- a/src/views/management/user/index.vue
+++ b/src/views/management/user/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full overflow-hidden">
+  <div class="h-full">
     <n-card title="用户管理" :bordered="false" class="rounded-8px shadow-sm">
       <n-space class="pb-12px" justify="space-between">
         <n-space>


### PR DESCRIPTION
## Pull Request 详情

请根据实际使用情况修改以下信息。

## 版本信息
0.10.3
## 解决了哪些问题

1.在生产环境每次页面刷新或关闭时都会重新缓存当前的主题配置，导致初始化主题配置时永远读取到是第一次缓存的主题配置，后续修改主题配置文件不会生效。

2.用户管理页面无法滚动。

## 是否关闭了某个 Issue
否
Closes #
