### PR TITLE
Update Docker deployment method and git hooks init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ pnpm build
 - Docker 部署 Soybean
 
 ```bash
-docker run --name soybean -p 80:80 -d soybeanjs/soybean-admin:v0.9.6
+docker build -t soybean-admin-image -f docker/Dockerfile .
+docker run -d -p 80:80 soybean-admin-image
 ```
 
 - 访问 SoybeanAdmin

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ docker run -d -p 80:80 soybean-admin-image
 
 项目已经内置 Angular 提交规范，直接执行 commit 命令即可生成符合 Angular 提交规范的 commit。
 
-项目已用 simple-git-hooks 代替了 husky, 旧版本用了 husky，执行 pnpm soy init-git-hooks 进行初始化配置
+项目已用 simple-git-hooks 代替了 husky, 旧版本用了 husky，执行 pnpm soy init-simple-git-hooks 进行初始化配置
 
 ## 浏览器支持
 


### PR DESCRIPTION
## Pull Request 详情

你好!

我很喜欢这个项目, 也很高兴能向您提交这个PR, 我把项目原来的通过 Docker Hub 构建镜像的方式改为了本地构建.

感谢您的审阅, 期待您的反馈.

谢谢~

## 版本信息
v0.10.3

## 解决了哪些问题

1. 在 Docker 部署过程运行命令`docker run --name soybean -p 80:80 -d soybeanjs/soybean-admin:v0.9.6`失败, 所以改为通过本地Dockerfile构建 Docker 镜像`docker build -t soybean-admin-image -f docker/Dockerfile .`, 然后运行镜像`docker run -d -p 80:80 soybean-admin-image`
2. 更新 git hooks 初始化命令为`pnpm soy init-simple-git-hooks`


## 是否关闭了某个 Issue
否

Closes #
