### PR TITLE
fix(projects): 修复路由命名为包含关系时导致导航数据出错的问题

### DIFF
--- a/src/utils/router/breadcrumb.ts
+++ b/src/utils/router/breadcrumb.ts
@@ -1,3 +1,4 @@
+import { getTopLevelMenu } from './helpers';
 /**
  * 获取面包屑数据
  * @param activeKey - 当前页面路由的key
@@ -17,13 +18,9 @@ export function getBreadcrumbByRouteKey(activeKey: string, menus: App.GlobalMenu
  */
 function getBreadcrumbMenu(activeKey: string, menus: App.GlobalMenuOption[]) {
   const breadcrumbMenu: App.GlobalMenuOption[] = [];
-  menus.some(menu => {
-    const flag = activeKey.includes(menu.routeName);
-    if (flag) {
-      breadcrumbMenu.push(...getBreadcrumbMenuItem(activeKey, menu));
-    }
-    return flag;
-  });
+  const topLevelMenu = getTopLevelMenu(activeKey, menus);
+  const options = getBreadcrumbMenuItem(activeKey, topLevelMenu as App.GlobalMenuOption);
+  breadcrumbMenu.push(...options);
   return breadcrumbMenu;
 }
 

--- a/src/utils/router/helpers.ts
+++ b/src/utils/router/helpers.ts
@@ -17,3 +17,18 @@ function getConstantRouteName(route: AuthRoute.Route) {
   }
   return names;
 }
+
+/**
+ * 根据路由名称查找顶级菜单
+ * @param routeName - 当前页面路由的key
+ * @param menus - 菜单数据
+ */
+export function getTopLevelMenu(routeName: string, menus: App.GlobalMenuOption[]): App.GlobalMenuOption | undefined {
+  return menus.find(item => {
+    if (item.routeName === routeName) return true;
+    if (Array.isArray(item.children)) {
+      return getTopLevelMenu(routeName, item.children);
+    }
+    return false;
+  });
+}

--- a/src/utils/router/menu.ts
+++ b/src/utils/router/menu.ts
@@ -63,18 +63,29 @@ export function translateMenuLabel(menus: App.GlobalMenuOption[]): App.GlobalMen
  * @param menus - 菜单数据
  */
 export function getActiveKeyPathsOfMenus(activeKey: string, menus: App.GlobalMenuOption[]) {
-  const keys = menus.map(menu => getActiveKeyPathsOfMenu(activeKey, menu)).flat(1);
-  return keys;
-}
-
-function getActiveKeyPathsOfMenu(activeKey: string, menu: App.GlobalMenuOption) {
-  const keys: string[] = [];
-  if (activeKey.startsWith(menu.routeName)) {
-    keys.push(menu.routeName);
+  const keys = [] as any;
+  const lists = [] as any;
+  function traverse(list: any, parent = null) {
+    list.forEach((t: any) => {
+      lists.push(t);
+      if (parent) {
+        t.parent = parent;
+      }
+      if (t.children) {
+        traverse(t.children, t);
+      }
+    });
   }
-  if (menu.children) {
-    keys.push(...menu.children.map(item => getActiveKeyPathsOfMenu(activeKey, item as App.GlobalMenuOption)).flat(1));
-  }
+  traverse(JSON.parse(JSON.stringify(menus)));
+  lists.forEach((t: App.GlobalMenuOption) => {
+    if (t.routeName === activeKey) {
+      let temp = t;
+      while (temp) {
+        keys.push(temp.routeName);
+        temp = temp.parent as App.GlobalMenuOption;
+      }
+    }
+  });
   return keys;
 }
 


### PR DESCRIPTION
## Pull Request 详情

正确获取导航信息

## 版本信息

## 解决了哪些问题
当顶级路由出现类似 A(route)和B(route-others)的类似命名时，目前导航组件获取的数据匹配规则是includes，这有可能会导致获取到的路由数据是错误的

## 是否关闭了某个 Issue

Closes #279
