### PR TITLE
feat(router): add sortRoutesByOrder function

### DIFF
--- a/src/store/modules/route/index.ts
+++ b/src/store/modules/route/index.ts
@@ -18,6 +18,7 @@ import {
   getGlobalMenusByAuthRoutes,
   getSelectedMenuKeyPathByKey,
   isRouteExistByRouteName,
+  sortRoutesByOrder,
   updateLocaleOfGlobalMenus
 } from './shared';
 
@@ -185,11 +186,13 @@ export const useRouteStore = defineStore(SetupStoreId.Route, () => {
    * @param routes Auth routes
    */
   function handleAuthRoutes(routes: ElegantConstRoute[]) {
-    const vueRoutes = getAuthVueRoutes(routes);
+    const sortRoutes = sortRoutesByOrder(routes);
+
+    const vueRoutes = getAuthVueRoutes(sortRoutes);
 
     addRoutesToVueRouter(vueRoutes);
 
-    getGlobalMenus(routes);
+    getGlobalMenus(sortRoutes);
 
     getCacheRoutes(vueRoutes);
   }

--- a/src/store/modules/route/shared.ts
+++ b/src/store/modules/route/shared.ts
@@ -45,6 +45,22 @@ function filterAuthRouteByRoles(route: ElegantConstRoute, roles: string[]) {
 }
 
 /**
+ * Sort routes by order
+ *
+ * @param routes An array of routes
+ * @returns A new array of routes sorted by order
+ *
+ *   This function sorts the routes by their order property, which is a number. If the order property is missing or
+ *   invalid, it is treated as 0. The routes with lower order values are placed before the routes with higher order
+ *   values. The function also sorts the children routes recursively, if any.
+ */
+export const sortRoutesByOrder = (routes: ElegantConstRoute[]): ElegantConstRoute[] => {
+  return routes
+    .sort((next, prev) => (Number(next.meta?.order) || 0) - (Number(prev.meta?.order) || 0))
+    .map(route => (route.children ? { ...route, children: sortRoutesByOrder(route.children) } : route));
+};
+
+/**
  * Get global menus by auth routes
  *
  * @param routes Auth routes


### PR DESCRIPTION
## Pull Request 详情
This function sorts the routes by their meta.order property, which is a number. If the meta.order property is missing or
invalid, it is treated as 0. The routes with lower meta.order values are placed before the routes with higher meta.order
values. The function also sorts the children routes recursively, if any.

## 版本信息
v1.0-beta

## 解决了哪些问题
Support routing sorting

## 是否关闭了某个 Issue
否
