### PR TITLE
fixed: proxy代理前缀冲突，导致地址指向错误，默认地址改为/proxy-default

### DIFF
--- a/env.config.ts
+++ b/env.config.ts
@@ -39,7 +39,7 @@ export function createServiceConfig(env: Env.ImportMeta) {
  */
 export function createProxyPattern(key?: App.Service.OtherBaseURLKey) {
   if (!key) {
-    return '/proxy';
+    return '/proxy-default';
   }
 
   return `/proxy-${key}`;


### PR DESCRIPTION
fixed: proxy代理前缀冲突，导致地址指向错误，默认地址改为/proxy-default