### PR TITLE
fix(projects): default proxy prefix

### DIFF
--- a/env.config.ts
+++ b/env.config.ts
@@ -39,7 +39,7 @@ export function createServiceConfig(env: Env.ImportMeta) {
  */
 export function createProxyPattern(key?: App.Service.OtherBaseURLKey) {
   if (!key) {
-    return '/proxy';
+    return '/proxy-default';
   }
 
   return `/proxy-${key}`;


### PR DESCRIPTION
# Pull Request 详情
proxy代理前缀冲突，导致代理后，请求一直发送默认地址

# 版本信息
v1.0-beta

# 解决了哪些问题
修复代理请求，都指向默认地址的问题

# 是否关闭了某个 Issue
否