### PR TITLE
feat(types): enhance Option type to support customizable label types

### DIFF
--- a/src/typings/common.d.ts
+++ b/src/typings/common.d.ts
@@ -14,7 +14,7 @@ declare namespace CommonType {
    * @property value: The option value
    * @property label: The option label
    */
-  type Option<K = string> = { value: K; label: string };
+  type Option<K = string, M = string> = { value: K; label: M };
 
   type YesOrNo = 'Y' | 'N';
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -22,7 +22,7 @@ export function transformRecordToOption<T extends Record<string, string>>(record
   return Object.entries(record).map(([value, label]) => ({
     value,
     label
-  })) as CommonType.Option<keyof T>[];
+  })) as CommonType.Option<keyof T, T[keyof T]>[];
 }
 
 /**
@@ -30,10 +30,10 @@ export function transformRecordToOption<T extends Record<string, string>>(record
  *
  * @param options
  */
-export function translateOptions(options: CommonType.Option<string>[]) {
+export function translateOptions(options: CommonType.Option<string, App.I18n.I18nKey>[]) {
   return options.map(option => ({
     ...option,
-    label: $t(option.label as App.I18n.I18nKey)
+    label: $t(option.label)
   }));
 }
 


### PR DESCRIPTION
When using `$t(item.label)` in a component, since `label` is not of type `I18nKey`, it may cause TypeScript to throw an error. To address this issue, I have refined the type hint for `label` to ensure it accurately suggests either the `I18nKey` type or other subtypes of `string`. This approach not only ensures type safety but also provides more flexible type support.