### PR TITLE
fix(types): The environment variable VITE_ICON_LOCAL_PREFIX has the w…

### DIFF
--- a/src/typings/vite-env.d.ts
+++ b/src/typings/vite-env.d.ts
@@ -25,7 +25,7 @@ declare namespace Env {
      *
      * This prefix is start with the icon prefix
      */
-    readonly VITE_ICON_LOCAL_PREFIX: 'local-icon';
+    readonly VITE_ICON_LOCAL_PREFIX: 'icon-local';
     /** backend service base url */
     readonly VITE_SERVICE_BASE_URL: string;
     /**


### PR DESCRIPTION
`VITE_ICON_LOCAL_PREFIX` 环境变量的类型错了，应该是 **icon-local** 而不是 **local-icon**。 这个错误导致我在看源码的过程中有点懵逼。`const collectionName = VITE_ICON_LOCAL_PREFIX.replace(${VITE_ICON_PREFIX}-, '');`  根据这行代码的 **ts** 提示来看，两个环境变量并不满足 **replace** 的条件。

全局搜索 `VITE_ICON_LOCAL_PREFIX` 这个变量就能发现问题。