### PR TITLE
typo(other): Correct the typos in the Chinese translation and change "局右" to "居右"。

### DIFF
--- a/src/locales/langs/zh-cn.ts
+++ b/src/locales/langs/zh-cn.ts
@@ -159,7 +159,7 @@ const local: App.I18n.Schema = {
         visible: '显示底部',
         fixed: '固定底部',
         height: '底部高度',
-        right: '底部局右'
+        right: '底部居右'
       },
       content: {
         title: '内容区域设置',


### PR DESCRIPTION

<img width="1062" height="614" alt="83611759494871_ pic_hd" src="https://github.com/user-attachments/assets/5fba79a5-22e1-4c31-8f77-31f164cdd7b8" />
