### PR TITLE
feat(styles): add text-autospace property to improve text layout

### DIFF
--- a/src/styles/css/global.css
+++ b/src/styles/css/global.css
@@ -6,6 +6,7 @@ html,
 body,
 #app {
   height: 100%;
+  text-autospace: normal;
 }
 
 html {


### PR DESCRIPTION
## Summary:
This PR adds the `text-autospace: normal` CSS property to the global styles to improve text layout and readability, particularly for mixed CJK (Chinese, Japanese, Korean) and non-CJK content.

## Changes:
- Added `text-autospace: normal` to the global CSS styles in `src/styles/css/global.css`

## Visual Comparison:

### Before:
<img width="2670" height="1164" alt="without text-autospace" src="https://github.com/user-attachments/assets/294969e8-0958-4792-a9f1-0d8760ad3f06" />

### After:
<img width="2772" height="1144" alt="with text-autospace: normal" src="https://github.com/user-attachments/assets/8b2cf935-00a5-4ace-b984-9199ef0ded7c" />


## Reference:
- [MDN Documentation: text-autospace](https://developer.mozilla.org/en-US/docs/Web/CSS/text-autospace)
- https://x.com/yisibl/status/1979132340942041270
