### PR TITLE
fix(styles): show light color scrollbar while dark mode is on

### DIFF
--- a/src/styles/scss/scrollbar.scss
+++ b/src/styles/scss/scrollbar.scss
@@ -1,6 +1,13 @@
-@mixin scrollbar($size: 7px, $color: rgba(0, 0, 0, 0.5)) {
+@mixin scrollbar($size: 7px, $color: rgba(0, 0, 0, 0.5), $dark-color: rgba(255, 255, 255, 0.5)) {
   scrollbar-width: thin;
   scrollbar-color: $color transparent;
+
+  // Dark theme override
+  .dark & {
+    // guide safari use light color scrollbar
+    color-scheme: dark;
+    scrollbar-color: $dark-color transparent;
+  }
 
   &::-webkit-scrollbar-thumb {
     background-color: $color;


### PR DESCRIPTION
## Summary:
This PR updated `src/styles/scss/scrollbar.scss` to display a light-colored scrollbar when dark mode is enabled.
fix: #834
## Changes:
```scss
@mixin scrollbar($size: 7px, $color: rgba(0, 0, 0, 0.5), $dark-color: rgba(255, 255, 255, 0.5)) {
...
  // Dark theme override
  .dark & {
    // guide safari use light color scrollbar
    color-scheme: dark;
    scrollbar-color: $dark-color transparent;
  }
 ...
 }
```
## Visual Comparison:
### Before:
<img width="2047" height="861" alt="Screenshot 2025-10-21 at 1 36 10 PM" src="https://github.com/user-attachments/assets/e8cd8cca-3e4f-43c8-809e-6435e50ad139" />

### After:
Chrome
<img width="1709" height="837" alt="Screenshot 2025-10-21 at 10 43 33 AM" src="https://github.com/user-attachments/assets/2ff7b9d5-ee4f-4dee-ae27-3bbf98397746" />
Firefox
<img width="2047" height="861" alt="Screenshot 2025-10-21 at 1 31 02 PM" src="https://github.com/user-attachments/assets/e05e4f06-91f4-44af-95ab-1ad4f081c001" />
Safari
<img width="1709" height="837" alt="Screenshot 2025-10-21 at 10 43 58 AM" src="https://github.com/user-attachments/assets/97e706f9-08ff-4317-ad35-a3fbf14c23c8" />

