### PR TITLE
refactor(table): handleAdd 方法重置 editingData

### DIFF
--- a/src/hooks/common/table.ts
+++ b/src/hooks/common/table.ts
@@ -181,13 +181,14 @@ export function useTableOperate<TableData>(
 
   const operateType = shallowRef<NaiveUI.TableOperateType>('add');
 
-  function handleAdd() {
-    operateType.value = 'add';
-    openDrawer();
-  }
-
   /** the editing row data */
   const editingData = shallowRef<TableData | null>(null);
+
+  function handleAdd() {
+    operateType.value = 'add';
+    editingData.value = null;
+    openDrawer();
+  }
 
   function handleEdit(id: TableData[keyof TableData]) {
     operateType.value = 'edit';


### PR DESCRIPTION
为了解决operate-drawer在add模式下参数的一致性问题。

当首次打开add模型的抽屉时，rowData是null，但是当add模式之前有edit模式的情况下，rowData就不为null了。导致add模式下，rowData参数的表现不一致。