### PR TITLE
fix(app): clear update interval after the isShow is set true

### DIFF
--- a/src/plugins/app.ts
+++ b/src/plugins/app.ts
@@ -31,7 +31,7 @@ export function setupAppVersionNotification() {
     }
 
     isShow = true;
-
+    clearInterval(updateInterval);
     // Show update notification
     const n = window.$notification?.create({
       title: $t('system.updateTitle'),


### PR DESCRIPTION
如果 isShow 设置为 true 之后，那么一定就不会更新，checkForUpdates 始终会被 return; 所以没必要还要定时执行，在 isShow = true 之后，直接清除定时器