### PR TITLE
feat(components): Add “Select All” to TableColumnSetting

### DIFF
--- a/src/components/advanced/table-column-setting.vue
+++ b/src/components/advanced/table-column-setting.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts" generic="T extends Record<string, unknown>, K = never">
+import { computed } from 'vue';
 import { VueDraggable } from 'vue-draggable-plus';
 import { $t } from '@/locales';
 
@@ -22,6 +23,40 @@ function handleFixed(column: NaiveUI.TableColumnCheck) {
   const nextIndex = index === fixedOptions.length - 1 ? 0 : index + 1;
   column.fixed = fixedOptions[nextIndex];
 }
+
+const visibleStats = computed(() => {
+  let total = 0;
+  let checked = 0;
+
+  columns.value.forEach(column => {
+    if (!column.visible) return;
+
+    total += 1;
+    if (column.checked) checked += 1;
+  });
+
+  return { total, checked };
+});
+
+const selectAllChecked = computed(() => {
+  const { total, checked } = visibleStats.value;
+
+  return total > 0 && checked === total;
+});
+
+const selectAllIndeterminate = computed(() => {
+  const { total, checked } = visibleStats.value;
+
+  return checked > 0 && checked < total;
+});
+
+function toggleSelectAll(checked: boolean) {
+  columns.value.forEach(column => {
+    if (!column.visible) return;
+
+    column.checked = checked;
+  });
+}
 </script>
 
 <template>
@@ -34,35 +69,49 @@ function handleFixed(column: NaiveUI.TableColumnCheck) {
         {{ $t('common.columnSetting') }}
       </NButton>
     </template>
-    <VueDraggable v-model="columns" :animation="150" filter=".none_draggable">
-      <div
-        v-for="item in columns"
-        :key="item.key"
-        class="h-36px flex-y-center justify-between gap-6px"
-        :class="{ hidden: !item.visible }"
-      >
-        <div class="flex-y-center rd-4px hover:(bg-primary bg-opacity-20)">
-          <icon-mdi-drag class="mr-8px h-full cursor-move text-icon" />
-          <NCheckbox v-model:checked="item.checked" class="none_draggable flex-1">
-            <template v-if="typeof item.title === 'function'">
-              <component :is="item.title" />
-            </template>
-            <template v-else>{{ item.title }}</template>
-          </NCheckbox>
-        </div>
-        <ButtonIcon
-          :disabled="!item.checked"
-          text
-          :focusable="false"
-          :tooltip-content="$t(tooltipRecord[item.fixed!])"
-          @click="handleFixed(item)"
+    <div>
+      <div class="h-36px flex-y-center rd-4px pl-26px hover:(bg-primary bg-opacity-20)">
+        <NCheckbox
+          :checked="selectAllChecked"
+          :indeterminate="selectAllIndeterminate"
+          :disabled="visibleStats.total === 0"
+          class="flex-1"
+          @update:checked="toggleSelectAll"
         >
-          <icon-octicon-pin-16 v-if="item.fixed === 'unFixed'" />
-          <icon-octicon-pin-16 v-else-if="item.fixed === 'left'" class="rotate-270" />
-          <icon-octicon-pin-slash-16 v-else />
-        </ButtonIcon>
+          {{ $t('common.selectAll') }}
+        </NCheckbox>
       </div>
-    </VueDraggable>
+      <NDivider class="!my-4px" />
+      <VueDraggable v-model="columns" :animation="150" filter=".none_draggable">
+        <div
+          v-for="item in columns"
+          :key="item.key"
+          class="h-36px flex-y-center justify-between gap-6px"
+          :class="{ hidden: !item.visible }"
+        >
+          <div class="h-full flex-y-center flex-1 rd-4px hover:(bg-primary bg-opacity-20)">
+            <icon-mdi-drag class="mr-8px h-full cursor-move text-icon" />
+            <NCheckbox v-model:checked="item.checked" class="none_draggable flex-1">
+              <template v-if="typeof item.title === 'function'">
+                <component :is="item.title" />
+              </template>
+              <template v-else>{{ item.title }}</template>
+            </NCheckbox>
+          </div>
+          <ButtonIcon
+            :disabled="!item.checked"
+            text
+            :focusable="false"
+            :tooltip-content="$t(tooltipRecord[item.fixed!])"
+            @click="handleFixed(item)"
+          >
+            <icon-octicon-pin-16 v-if="item.fixed === 'unFixed'" />
+            <icon-octicon-pin-16 v-else-if="item.fixed === 'left'" class="rotate-270" />
+            <icon-octicon-pin-slash-16 v-else />
+          </ButtonIcon>
+        </div>
+      </VueDraggable>
+    </div>
   </NPopover>
 </template>
 

--- a/src/locales/langs/en-us.ts
+++ b/src/locales/langs/en-us.ts
@@ -15,6 +15,7 @@ const local: App.I18n.Schema = {
     cancel: 'Cancel',
     close: 'Close',
     check: 'Check',
+    selectAll: 'Select All',
     expandColumn: 'Expand Column',
     columnSetting: 'Column Setting',
     config: 'Config',

--- a/src/locales/langs/zh-cn.ts
+++ b/src/locales/langs/zh-cn.ts
@@ -15,6 +15,7 @@ const local: App.I18n.Schema = {
     cancel: '取消',
     close: '关闭',
     check: '勾选',
+    selectAll: '全选',
     expandColumn: '展开列',
     columnSetting: '列设置',
     config: '配置',

--- a/src/typings/app.d.ts
+++ b/src/typings/app.d.ts
@@ -326,6 +326,7 @@ declare namespace App {
         cancel: string;
         close: string;
         check: string;
+        selectAll: string;
         expandColumn: string;
         columnSetting: string;
         config: string;


### PR DESCRIPTION
Adds a “Select All” option to the table column settings popover

<img width="856" height="986" alt="image" src="https://github.com/user-attachments/assets/61216cbc-0933-4174-a067-31ac5bc99ded" />
