### PR TITLE
feat(types): Added type definition `force` to router push options.

### DIFF
--- a/src/typings/app.d.ts
+++ b/src/typings/app.d.ts
@@ -196,6 +196,7 @@ declare namespace App {
     type RouterPushOptions = {
       query?: Record<string, string>;
       params?: Record<string, string>;
+      force?: boolean;
     };
 
     /** The global header props */


### PR DESCRIPTION
在类型 App.RouterPushOptions 中添加 force?: boolean;