### PR TITLE
optimize(projects): modify the injection location of the token.

### DIFF
--- a/src/store/modules/auth/index.ts
+++ b/src/store/modules/auth/index.ts
@@ -19,7 +19,7 @@ export const useAuthStore = defineStore(SetupStoreId.Auth, () => {
   const { toLogin, redirectFromLogin } = useRouterPush(false);
   const { loading: loginLoading, startLoading, endLoading } = useLoading();
 
-  const token = ref(getToken());
+  const token = ref('');
 
   const userInfo: Api.Auth.UserInfo = reactive({
     userId: '',
@@ -159,9 +159,10 @@ export const useAuthStore = defineStore(SetupStoreId.Auth, () => {
   }
 
   async function initUserInfo() {
-    const hasToken = getToken();
+    const maybeToken = getToken();
 
-    if (hasToken) {
+    if (maybeToken) {
+      token.value = maybeToken;
       const pass = await getUserInfo();
 
       if (!pass) {


### PR DESCRIPTION
在某些系统里，getToken 可能是个异步的操作，比如在 supabase 当后端的时候，token 的获取是这样的：
``` js
const {
    data: { session }
  } = await supabase.auth.getSession();
  const token = session?.access_token || '';
```

这个时候 `authStore`的  `token` 就无法通过 `getToken()` 去初始化，放在 `initUserInfo` 里进行可以提高这部分代码的兼容性