### PR TITLE
fix(projects): fix wrong new tab opening for external link navigation.

### DIFF
--- a/src/router/guard/route.ts
+++ b/src/router/guard/route.ts
@@ -38,8 +38,7 @@ export function createRouteGuard(router: Router) {
 
     // if the route does not need login, then it is allowed to access directly
     if (!needLogin) {
-      handleRouteSwitch(to, from);
-      return;
+      return handleRouteSwitch(to, from);
     }
 
     // the route need login but the user is not logged in, then switch to the login page
@@ -53,7 +52,7 @@ export function createRouteGuard(router: Router) {
     }
 
     // switch route normally
-    handleRouteSwitch(to, from);
+    return handleRouteSwitch(to, from);
   });
 }
 


### PR DESCRIPTION
# 修复路由外链跳转时错误打开新 tab 的问题

## 根因：
handleRouteSwitch 返回 { path: from.fullPath, replace: true, ... } 来阻止导航并回退到原页面，但调用处没有 return，返回值被丢弃。beforeEach 没有收到任何返回值（相当于 undefined），路由导航正常继续，进入了 document_project-link 路由（iframe 页）。

## 修复：
两处调用都加了 return

// 修复前
handleRouteSwitch(to, from);   // 返回值丢失
return;
// 修复后  
return handleRouteSwitch(to, from);  // 正确返回 { path: from.fullPath, replace: true, ... }


现在当 to.meta.href 有值时，window.open 打开外链，同时 beforeEach 返回 from 的路径，阻止路由跳转到 iframe 页。