### PR TITLE
优化 pnpm commit 交互体验

### DIFF
--- a/packages/scripts/src/commands/git-commit.ts
+++ b/packages/scripts/src/commands/git-commit.ts
@@ -17,7 +17,14 @@ interface PromptObject {
  * @param lang
  */
 export async function gitCommit(lang: Lang = 'en-us') {
-  const { gitCommitMessages, gitCommitTypes, gitCommitScopes } = locales[lang];
+  const { gitCommitMessages, gitCommitNoStaged, gitCommitTypes, gitCommitScopes } = locales[lang];
+
+  const stagedFiles = await execCommand('git', ['diff', '--cached', '--name-only']);
+
+  if (!stagedFiles) {
+    console.error(gitCommitNoStaged);
+    process.exit(1);
+  }
 
   const typesChoices = gitCommitTypes.map(([value, msg]) => {
     const nameWithSuffix = `${value}:`;

--- a/packages/scripts/src/commands/git-commit.ts
+++ b/packages/scripts/src/commands/git-commit.ts
@@ -42,25 +42,41 @@ export async function gitCommit(lang: Lang = 'en-us') {
     message: `${value.padEnd(30)} (${msg})`
   }));
 
-  const result = await prompt<PromptObject>([
-    {
-      name: 'types',
-      type: 'select',
-      message: gitCommitMessages.types,
-      choices: typesChoices
-    },
-    {
-      name: 'scopes',
-      type: 'select',
-      message: gitCommitMessages.scopes,
-      choices: scopesChoices
-    },
-    {
-      name: 'description',
-      type: 'text',
-      message: gitCommitMessages.description
+  // Suppress ERR_USE_AFTER_CLOSE thrown by enquirer's readline cleanup on Ctrl+C (Node.js v24+)
+  const errorHandler = (error: NodeJS.ErrnoException) => {
+    if (error.code === 'ERR_USE_AFTER_CLOSE') {
+      process.exit(0);
     }
-  ]);
+  };
+  process.on('uncaughtException', errorHandler);
+
+  let result: PromptObject;
+
+  try {
+    result = await prompt<PromptObject>([
+      {
+        name: 'types',
+        type: 'select',
+        message: gitCommitMessages.types,
+        choices: typesChoices
+      },
+      {
+        name: 'scopes',
+        type: 'select',
+        message: gitCommitMessages.scopes,
+        choices: scopesChoices
+      },
+      {
+        name: 'description',
+        type: 'text',
+        message: gitCommitMessages.description
+      }
+    ]);
+  } catch {
+    process.exit(0);
+  } finally {
+    process.off('uncaughtException', errorHandler);
+  }
 
   const breaking = result.description.startsWith('!') ? '!' : '';
 

--- a/packages/scripts/src/locales/index.ts
+++ b/packages/scripts/src/locales/index.ts
@@ -37,6 +37,7 @@ export const locales = {
       ['release', '发布项目新版本'],
       ['other', '其他的变更']
     ] as [string, string][],
+    gitCommitNoStaged: `${bgRed(' 错误 ')} ${red('暂存区没有文件，请先使用 git add 添加文件后再提交!')}`,
     gitCommitVerify: `${bgRed(' 错误 ')} ${red('git 提交信息必须符合 Conventional Commits 标准!')}\n\n${green(
       '推荐使用命令 `pnpm commit` 生成符合 Conventional Commits 标准的提交信息。\n获取有关 Conventional Commits 的更多信息，请访问此链接: https://conventionalcommits.org'
     )}`
@@ -75,6 +76,7 @@ export const locales = {
       ['release', 'release project'],
       ['other', 'other changes']
     ] as [string, string][],
+    gitCommitNoStaged: `${bgRed(' ERROR ')} ${red('No files in staging area, please use git add to stage files first!')}`,
     gitCommitVerify: `${bgRed(' ERROR ')} ${red('git commit message must match the Conventional Commits standard!')}\n\n${green(
       'Recommended to use the command `pnpm commit` to generate Conventional Commits compliant commit information.\nGet more info about Conventional Commits, follow this link: https://conventionalcommits.org'
     )}`


### PR DESCRIPTION
1. 修复 Ctrl+C 退出时报 ERR_USE_AFTER_CLOSE 错误

  在 pnpm commit 的交互式提示中按 Ctrl+C 取消时，Node.js 会因为 enquirer 内部的 readline 已关闭而抛出
  ERR_USE_AFTER_CLOSE 异常。

  修复方式： 通过 process.on('uncaughtException') 在进程级别拦截该错误，确保 Ctrl+C 能干净退出。
<img width="303" height="105" alt="image" src="https://github.com/user-attachments/assets/8b66d82c-d989-45b0-93da-75b54ed04ce5" />


  2. 提交前检查 git 暂存区

  之前执行 pnpm commit 时，即使用户忘记 git add，也会进入完整的交互流程，到最后 git commit 才报错，体验较差。

  修复方式： 在显示交互提示之前先检查暂存区是否有文件，若为空则立即提示用户并退出，避免无效操作。

<img width="710" height="188" alt="image" src="https://github.com/user-attachments/assets/a8a222b3-80bf-4a63-b7b2-48d8b685086b" />


  测试验证

  - pnpm commit 后按 Ctrl+C 能正常退出，无报错
  - 未 git add 时执行 pnpm commit 直接提示暂存区为空
  - 正常提交流程不受影响
  - typecheck、lint、fmt 均通过